### PR TITLE
Remove automatically adding an include as an option

### DIFF
--- a/smrt-gulp-r/index.js
+++ b/smrt-gulp-r/index.js
@@ -55,11 +55,6 @@ function normalizeFileOptions(file, encoding, options) {
         normalizeFileOptionsDeferred = Q.defer(),
         normalizeFileOptionsPromise = normalizeFileOptionsDeferred.promise;
 
-    if (fileOptions.name) {
-        fileOptions.name = path.relative(fileOptions.baseUrl, fileOptions.name);
-    } else {
-        fileOptions.name = include;
-    }
 
     normalizeFileOptionsDeferred.resolve(fileOptions);
 

--- a/smrt-gulp-r/index.js
+++ b/smrt-gulp-r/index.js
@@ -57,7 +57,6 @@ function normalizeFileOptions(file, encoding, options) {
 
     if (fileOptions.name) {
         fileOptions.name = path.relative(fileOptions.baseUrl, fileOptions.name);
-        fileOptions.include = include;
     } else {
         fileOptions.name = include;
     }


### PR DESCRIPTION
If user's would like to include, they should pass an 'include' parameter.
